### PR TITLE
Fix bug of not passing command flags to spawned process

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,15 @@ if (argv.p) {
   process.exit()
 }
 
-spawn(argv._[0], argv._.slice(1), {stdio: 'inherit'})
+const cmdToRun = argv._[0]
+if (!cmdToRun){ // No command given
+  process.exit()
+}
+
+const cmdIndex = process.argv.indexOf(argv._[0])
+const cmdArgs = process.argv.slice(cmdIndex)
+
+spawn(cmdArgs[0], cmdArgs.slice(1), {stdio: 'inherit'})
   .on('exit', function (exitCode) {
     process.exit(exitCode)
   })

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "A global executable to run applications with the ENV variables loaded by dotenv",
   "version": "1.4.0",
   "author": "caske33",
+  "contributors": [
+    "Michael Grinich (https://github.com/grinich)"
+  ],
   "bin": {
     "dotenv": "./cli.js"
   },


### PR DESCRIPTION
e.g. running

$ dotenv -e test.env jest --coverage

would not pass the --coverage flag to jest