### PR TITLE
fix: 'dotenv' and 'dotenv-expand' as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
   },
   "dependencies": {
     "cross-spawn": "^4.0.0",
-    "dotenv": "^7.0.0",
-    "dotenv-expand": "^5.0.0",
     "minimist": "^1.1.3"
   },
   "devDependencies": {
     "standard": "^12.0.1"
+  },
+  "peerDependencies": {
+    "dotenv": "^7.0.0",
+    "dotenv-expand": "^5.0.0"
   },
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
fixes: #20