### PR TITLE
feat: add help

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,6 +7,23 @@ var argv = require('minimist')(process.argv.slice(2))
 var dotenv = require('dotenv')
 var dotenvExpand = require('dotenv-expand')
 
+function print_help() {
+  console.log([
+    'Usage: dotenv [--help] [-e <path>[ -e <path>...]] [-p <variable name>] [command]',
+    '  --help              print help',
+    '  -e <path>           add .env file to environment, multiple arguments allowed',
+    '  -p <variable name>  print variable value to the console',
+    '',
+    '  If you do not specify -p, you must specify a command to be run.',
+    ''
+  ].join('\n'));
+}
+
+if (argv.help) {
+  print_help();
+  process.exit();
+}
+
 var paths = ['.env']
 if (argv.e) {
   if (typeof argv.e === 'string') {
@@ -24,7 +41,13 @@ if (argv.p) {
   process.exit()
 }
 
-spawn(argv._[0], argv._.slice(1), { stdio: 'inherit' })
+var command = argv._[0];
+if (!command) {
+  print_help();
+  process.exit(1);
+}
+
+spawn(command, argv._.slice(1), { stdio: 'inherit' })
   .on('exit', function (exitCode) {
     process.exit(exitCode)
   })

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "dotenv-cli",
   "description": "A global executable to run applications with the ENV variables loaded by dotenv",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "entropitor",
   "bin": {
     "dotenv": "./cli.js"
   },
   "dependencies": {
     "cross-spawn": "^7.0.1",
-    "dotenv": "^8.1.0",
+    "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
-    "minimist": "^1.1.3"
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "standard": "^14.3.1"
@@ -22,6 +22,5 @@
   "scripts": {
     "lint": "standard"
   },
-  "resolutions": {
-  }
+  "resolutions": {}
 }


### PR DESCRIPTION
This adds help/usage:

```
Usage: dotenv [--help] [-e <path>[ -e <path>...]] [-p <variable name>] [command]
  --help              print help
  -e <path>           add .env file to environment, multiple arguments allowed
  -p <variable name>  print variable value to the console

  If you do not specify -p, you must specify a command to be run.
```