### PR TITLE
fix: do not print 'undefined' when a variable is not defined, instead print the empty string

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,7 @@ paths.forEach(function (env) {
 
 if (argv.p) {
   var value = process.env[argv.p];
-  console.log(typeof value !== 'undefined' ? value : '' );
+  console.log(typeof value !== 'undefined' ? value : '');
   process.exit()
 }
 

--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,8 @@ paths.forEach(function (env) {
 })
 
 if (argv.p) {
-  console.log(process.env[argv.p])
+  var value = process.env[argv.p];
+  console.log(typeof value !== 'undefined' ? value : '' );
   process.exit()
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dotenv-cli",
   "description": "A global executable to run applications with the ENV variables loaded by dotenv",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": "entropitor",
   "bin": {
     "dotenv": "./cli.js"


### PR DESCRIPTION
This will not print 'undefined' to the console when a variable is missing, instead it will print the empty string. This avoids an issue where if a variable is unset, but you're executing a bash substitution like:

```
echo $( npx dotenv -p FOO )
```

It will not look like FOO equals the string 'undefined', instead it will echo nothing.