### PR TITLE
Cascade -e files when combined with -c

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ you might expect `dotenv echo "$SAY_HI"` to display `hello!`. In fact, this is n
 One possible way to get the desired result is:
 
 ```
-dotenv -- bash -c 'echo "$SAY_HI"'
+$ dotenv -- bash -c 'echo "$SAY_HI"'
 ```
 
 In bash, everything between `'` is not interpreted but passed as is. Since `$SAY_HI` is inside `''` brackets, it's passed as a string literal.
 
 Therefore, `dotenv-cli` will start a child process `bash -c 'echo "$SAY_HI"'` with the env variable `SAY_HI` set correctly which means bash will run `echo "$SAY_HI"` in the right environment which will print correctly `hello`
+
+### Debugging
+
+You can add the `--debug` flag to output the `.env` files that would be processed and exit.
 
 ## License
 

--- a/cli.js
+++ b/cli.js
@@ -9,8 +9,9 @@ var dotenvExpand = require('dotenv-expand')
 
 function printHelp () {
   console.log([
-    'Usage: dotenv [--help] [-e <path>] [-p <variable name>] [-c [environment]] [-- command]',
+    'Usage: dotenv [--help] [--debug] [-e <path>] [-p <variable name>] [-c [environment]] [-- command]',
     '  --help              print help',
+    '  --debug             output the files that would be processed but don\'t actually parse them or run the `command`',
     '  -e <path>           parses the file <path> as a `.env` file and adds the variables to the environment',
     '  -e <path>           multiple -e flags are allowed',
     '  -p <variable>       print value of <variable> to the console. If you specify this, you do not have to specify a `command`',
@@ -43,6 +44,11 @@ if (argv.e) {
 
 if (paths.length === 0) {
   paths.push('.env')
+}
+
+if (argv.debug) {
+  console.log(paths)
+  process.exit()
 }
 
 paths.forEach(function (env) {

--- a/cli.js
+++ b/cli.js
@@ -38,10 +38,10 @@ if (argv.e) {
 }
 
 if (argv.c) {
-  paths = paths.reduce((acc, p) => acc.concat(
+  paths = paths.reduce((accumulator, path) => accumulator.concat(
     typeof argv.c === 'string'
-      ? [`${p}.${argv.c}.local`, `${p}.${argv.c}`, `${p}.local`, p]
-      : [`${p}.local`, p]
+      ? [`${path}.${argv.c}.local`, `${path}.${argv.c}`, `${path}.local`, path]
+      : [`${path}.local`, path]
   ), [])
 }
 

--- a/cli.js
+++ b/cli.js
@@ -27,23 +27,22 @@ if (argv.help) {
 
 var paths = []
 
-if (argv.c) {
-  if (typeof argv.c === 'string') {
-    paths.push(`.env.${argv.c}.local`, `.env.${argv.c}`)
-  }
-  paths.push(".env.local", ".env")
-}
-
 if (argv.e) {
   if (typeof argv.e === 'string') {
     paths.push(argv.e)
   } else {
     paths.push(...argv.e)
   }
+} else {
+  paths.push('.env')
 }
 
-if (paths.length === 0) {
-  paths.push('.env')
+if (argv.c) {
+  paths = paths.reduce((acc, p) => acc.concat(
+    typeof argv.c === 'string'
+      ? [`${p}.${argv.c}.local`, `${p}.${argv.c}`, `${p}.local`, p]
+      : [`${p}.local`, p]
+  ), [])
 }
 
 if (argv.debug) {


### PR DESCRIPTION
This change makes it so that when combining the `-c` and `-e` flags it is the _extra_ files that will get the .local and environment specific versions. This is a change from the current behavior which cascades to `.env.local`, `.env`, `extra` so this may necessitate a major version bump, but I think is a more consistent behavior.

To demonstrate…

| flags | original | new |
| --- | --- | --- |
|  | `[ '.env' ]` | `[ '.env' ]` |
| `-c` | `[ '.env.local', '.env' ]` | `[ '.env.local', '.env' ]` |
| `-c foo` | `[ '.env.foo.local', '.env.foo', '.env.local', '.env' ]` | `[ '.env.foo.local', '.env.foo', '.env.local', '.env' ]` |
| `-e bar` | `[ 'bar' ]` | `[ 'bar' ]` |
| `-c -e bar` | `[ '.env.local', '.env', 'bar' ]` | `[ 'bar.local', 'bar' ]` |
| `-c foo -e bar` | `[ '.env.foo.local', '.env.foo', '.env.local', '.env', 'bar' ]` | `[ 'bar.foo.local', 'bar.foo', 'bar.local', 'bar' ]` |

I also added a `--debug` flag to make it easier to see what files `dotenv-cli` will process.

Fixes  #43