### PR TITLE
fix(parsing): args are not parsed correctly on some edge case

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 var spawn = require('cross-spawn')
 var path = require('path')
 
-var argv = require('minimist')(process.argv.slice(2))
+var argv = require('minimist')(process.argv.slice(2), { stopEarly: true })
 var dotenv = require('dotenv')
 var dotenvExpand = require('dotenv-expand')
 


### PR DESCRIPTION
This is our use case:
```
dotenv -e ./env.openapi openapi-sync-gitea --ref SOME_VAR --owner SOME_VAR --repo SOME_VAR --filePath SOME_VAR --host SOME_VAR --output SOME_VAR
```

If `stopEarly` is not enabled, the pasing result is:
```
  _: [ 'openapi-sync-gitea' ],
  e: './env.openapi',
  ref: 'SOME_VAR',
  owner: 'SOME_VAR',
  repo: 'SOME_VAR',
  filePath: 'SOME_VAR',
  host: 'SOME_VAR',
  output: 'SOME_VAR'
}
```

Based on the final block of this file:

```
spawn(command, argv._.slice(1), { stdio: 'inherit' })
  .on('exit', function (exitCode) {
    process.exit(exitCode)
  })
```

Only `openapi-sync-gitea` is passed to `spawn`, all other parameters are dropped.

By adding the parameter, we could get:

```
{
  _: [
    'openapi-sync-gitea',
    '--ref',
    'SOME_VAR',
    '--owner',
    'SOME_VAR',
    '--repo',
    'SOME_VAR',
    '--filePath',
    'SOME_VAR',
    '--host',
    'SOME_VAR',
    '--output',
    'SOME_VAR'
  ],
  e: './env.openapi'
}
```

This is a correct result.