### PR TITLE
Correctly handle killed sub-processes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,6 +88,10 @@ if (!command) {
 }
 
 spawn(command, argv._.slice(1), { stdio: 'inherit' })
-  .on('exit', function (exitCode) {
-    process.exit(exitCode)
+  .on('exit', function (exitCode, signal) {
+    if (typeof exitCode === 'number') {
+      process.exit(exitCode)
+    } else {
+      process.kill(process.pid, signal)
+    }
   })


### PR DESCRIPTION
Fixes #60.

[Node docs](https://nodejs.org/docs/latest-v16.x/api/child_process.html#event-exit) say that the `exit` event will receive the exit code and the signal as arguments. One of these is guaranteed to be non-null. In our case, if a sub-process was terminated involuntarily, `exitCode` was `null`, and running `process.exit(exitCode)` resulted in exit code 0.