### PR TITLE
fix(65): Setting variable does not work when value has dash: Updates …

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ if (argv.c) {
 }
 
 function validateCmdVariable (param) {
-  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&-/:;.]+$/)) {
+  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&\-/:;.]+$/)) {
     console.error('Unexpected argument ' + param + '. Expected variable in format variable=value')
     process.exit(1)
   }

--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ if (argv.c) {
 }
 
 function validateCmdVariable (param) {
-  if (!param.match(/^\w+=\w+$/)) {
+  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&-/:;.]+$/)) {
     console.error('Unexpected argument ' + param + '. Expected variable in format variable=value')
     process.exit(1)
   }


### PR DESCRIPTION
My first PR so please be gentle 😁 

I've added a new regex. It might be far from the greatest approach but seemed like a quick fix for something that's causing me and others issues. 

Tested against 
```shell
node cli.js -v test="$(echo bax; echo foo=bar)" -p test
node cli.js -v test="123-4543-213" -p test
```

Also added examples https://regexr.com/6i33o