### PR TITLE
Update minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cross-spawn": "^7.0.3",
     "dotenv": "^16.0.0",
     "dotenv-expand": "^8.0.1",
-    "minimist": "^1.2.5"
+    "minimist": "^1.2.6"
   },
   "devDependencies": {
     "standard": "^16.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,15 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As stated in the [minimist](https://github.com/substack/minimist) readme file, version 1.2.6 or later should be used due to [security reasons](https://github.com/substack/minimist#security).