### PR TITLE
fix: Add asterisk to the list of valid value characters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ if (argv.c) {
 }
 
 function validateCmdVariable (param) {
-  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&\-/:;.]+$/)) {
+  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&\-/:;.*]+$/)) {
     console.error('Unexpected argument ' + param + '. Expected variable in format variable=value')
     process.exit(1)
   }


### PR DESCRIPTION
My use case was to allows for wildcards with the [debug](https://npmjs.org/package/debug) module. E.g. `dotenv -v DEBUG=myLib:* node testMyLib.js`.
Probably has other utilities too, of course.

Going off of #65, I also forked the regexr pattern and added a new test: https://regexr.com/6rfhn