### PR TITLE
feat: expose 'override' option from 'dotenv'

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Therefore, `dotenv-cli` will start a child process `bash -c 'echo "$SAY_HI"'` wi
 
 You can add the `--debug` flag to output the `.env` files that would be processed and exit.
 
+### Override
+
+Override any environment variables that have already been set on your machine with values from your .env file.
+
+```bash
+dotenv -c test -o -- jest
+```
+
 ## License
 
 [MIT](https://en.wikipedia.org/wiki/MIT_License)

--- a/cli.js
+++ b/cli.js
@@ -19,6 +19,7 @@ function printHelp () {
     '  -p <variable>       print value of <variable> to the console. If you specify this, you do not have to specify a `command`',
     '  -c [environment]    support cascading env variables from `.env`, `.env.<environment>`, `.env.local`, `.env.<environment>.local` files',
     '  --no-expand         skip variable expansion',
+    '  -o, --override      override system variables',
     '  command             `command` is the actual command you want to run. Best practice is to precede this command with ` -- `. Everything after `--` is considered to be your command. So any flags will not be parsed by this tool but be passed to your command. If you do not do it, this tool will strip those flags'
   ].join('\n'))
 }
@@ -72,7 +73,8 @@ if (argv.debug) {
 }
 
 paths.forEach(function (env) {
-  var parsedFile = dotenv.config({ path: path.resolve(env) })
+  const override = argv.o || argv.override;
+  var parsedFile = dotenv.config({ path: path.resolve(env), override })
   if (argv.expand !== false) {
     dotenvExpand(parsedFile)
   }


### PR DESCRIPTION
Expose `override` from `dotenv`.

Users can pass `-o` or `--override`.

Absent, the value is false.

Resolves: https://github.com/entropitor/dotenv-cli/issues/85