### PR TITLE
fix: invert file order for override+cascade

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -41,11 +41,15 @@ if (argv.e) {
 }
 
 if (argv.c) {
-  paths = paths.reduce((accumulator, path) => accumulator.concat(
-    typeof argv.c === 'string'
+  const override = argv.o || argv.override;
+  paths = paths.reduce((accumulator, path) => {
+    let cascadePaths = typeof argv.c === 'string'
       ? [`${path}.${argv.c}.local`, `${path}.local`, `${path}.${argv.c}`, path]
-      : [`${path}.local`, path]
-  ), [])
+      : [`${path}.local`, path];
+    // when enabling environment overrides, invert the cascade order because values in the last file win
+    if (override) cascadePaths = cascadePaths.reverse();
+    return accumulator.concat(cascadePaths)
+  }, [])
 }
 
 function validateCmdVariable (param) {


### PR DESCRIPTION
Uniquely when "cascade" is set along with "override", the order of precedence is effectively inverted, causing the values in the last file in the array to win out.

In this change, when "cascade" is supplied with "override", reverse the files array.

<img width="367" alt="Screenshot 2023-06-27 at 2 24 41 PM" src="https://github.com/entropitor/dotenv-cli/assets/992483/5b6ff7b2-c1ce-4ba9-ad0c-7d16a8fdedd3">


fixes: https://github.com/entropitor/dotenv-cli/issues/89