### PR TITLE
fix: Allow Whitespace in CLI Variable Values

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,12 +56,13 @@ if (argv.c) {
 }
 
 function validateCmdVariable (param) {
-  if (!param.match(/^\w+=[a-zA-Z0-9"=^!?%@_&\-/:;.]+$/)) {
-    console.error('Unexpected argument ' + param + '. Expected variable in format variable=value')
+  const [, key, val] = param.match(/^(\w+)=([\s\S]+)$/m) || []
+  if (!key || !val) {
+    console.error(`Invalid variable name. Expected variable in format '-v variable=value', but got: \`-v ${param}\`.`)
     process.exit(1)
   }
 
-  return param
+  return [key, val]
 }
 const variables = []
 if (argv.v) {
@@ -71,7 +72,7 @@ if (argv.v) {
     variables.push(...argv.v.map(validateCmdVariable))
   }
 }
-const parsedVariables = dotenv.parse(Buffer.from(variables.join('\n')))
+const parsedVariables = Object.fromEntries(variables)
 
 if (argv.debug) {
   console.log(paths)
@@ -89,6 +90,9 @@ Object.assign(process.env, parsedVariables)
 
 if (argv.p) {
   const value = process.env[argv.p]
+  if (typeof value === 'string') {
+    value = `\`${value}\``
+  }
   console.log(value != null ? value : '')
   process.exit()
 }

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-var spawn = require('cross-spawn')
-var path = require('path')
+const spawn = require('cross-spawn')
+const path = require('path')
 
-var argv = require('minimist')(process.argv.slice(2))
-var dotenv = require('dotenv')
-var dotenvExpand = require('dotenv-expand').expand
+const argv = require('minimist')(process.argv.slice(2))
+const dotenv = require('dotenv')
+const dotenvExpand = require('dotenv-expand').expand
 
 function printHelp () {
   console.log([
@@ -29,14 +29,14 @@ if (argv.help) {
   process.exit()
 }
 
-const override = argv.o || argv.override;
+const override = argv.o || argv.override
 
 if (argv.c && override) {
   console.error('Invalid arguments. Cascading env variables conflicts with overrides.')
   process.exit(1)
 }
 
-var paths = []
+let paths = []
 if (argv.e) {
   if (typeof argv.e === 'string') {
     paths.push(argv.e)
@@ -63,7 +63,7 @@ function validateCmdVariable (param) {
 
   return param
 }
-var variables = []
+const variables = []
 if (argv.v) {
   if (typeof argv.v === 'string') {
     variables.push(validateCmdVariable(argv.v))
@@ -71,7 +71,7 @@ if (argv.v) {
     variables.push(...argv.v.map(validateCmdVariable))
   }
 }
-var parsedVariables = dotenv.parse(Buffer.from(variables.join('\n')))
+const parsedVariables = dotenv.parse(Buffer.from(variables.join('\n')))
 
 if (argv.debug) {
   console.log(paths)
@@ -80,7 +80,7 @@ if (argv.debug) {
 }
 
 paths.forEach(function (env) {
-  var parsedFile = dotenv.config({ path: path.resolve(env), override })
+  const parsedFile = dotenv.config({ path: path.resolve(env), override })
   if (argv.expand !== false) {
     dotenvExpand(parsedFile)
   }
@@ -88,12 +88,12 @@ paths.forEach(function (env) {
 Object.assign(process.env, parsedVariables)
 
 if (argv.p) {
-  var value = process.env[argv.p]
+  const value = process.env[argv.p]
   console.log(value != null ? value : '')
   process.exit()
 }
 
-var command = argv._[0]
+const command = argv._[0]
 if (!command) {
   printHelp()
   process.exit(1)


### PR DESCRIPTION
Fixes #78
Fixes #75

- [x] Linted
- [x] Avoids Security Risks
- [x] Simplifies regular expression for maintainability
- [x] Allows for Whitespace, including new line characters in values (expected when paired with `dotenv`)
- [x] Prevents illegal identifiers
- [x] No new dependencies
- [x] Tested/testable

[Click here to review just the changes in this PR without the changes made by the linter](https://github.com/entropitor/dotenv-cli/pull/105/commits/93a2d1274dc7c5dce874de92d66fdb94b0eb741a).

## Test Cases

**Original Security Issue (<a href="https://github.com/entropitor/dotenv-cli/pull/57#issuecomment-951203381">Details Here</a>)**:

```
node cli.js -v test="$(echo bax; echo foo=bar)" --debug
```
```javascript
[ '.env' ]
{ test: 'bax\nfoo=bar' }
```

**Complex Test:**

```
node cli.js -v foo=bar=baz -v "pew=pew" -v NODE_OPTIONS='--no-experimental-fetch --trace-warnings --loader=ts-node/tsm --loader=esmock' --debug
```
```javascript
[ '.env' ]
{
  foo: 'bar=baz',
  pew: 'pew',
  NODE_OPTIONS: '--no-experimental-fetch --trace-warnings --loader=ts-node/tsm --loader=esmock'
}
```

<details>
<summary>Other Tests</summary>

```
node cli.js -v NODE_OPTIONS=--no-experimental-fetch --debug
```
```javascript
[ '.env' ]
{ NODE_OPTIONS: '--no-experimental-fetch' }
```
---------

```
node cli.js -v NODE_OPTIONS=--loader=esmock --debug
```
```javascript
[ '.env' ]
{ NODE_OPTIONS: '--loader=esmock' }
```
---------

```
node cli.js -v NODE_OPTIONS='--no-experimental-fetch --trace-warnings' --debug
```
```javascript
[ '.env' ]
{ NODE_OPTIONS: '--no-experimental-fetch --trace-warnings' }
```
---------

```
node cli.js -v test1=foo --debug
```
```javascript
[ '.env' ]
{ test1: 'foo' }
```
---------

```
node cli.js -v test2='bar' --debug
```
```javascript
[ '.env' ]
{ test2: 'bar' }
```
---------

```
node cli.js -v test3="'baz'" --debug
```
```javascript
[ '.env' ]
{ test3: "'baz'" }
```
---------

```
node cli.js \
    -v foo=bar=baz \
    -v "pew=pew" \
    -v meow="mix" \
    -v "foos"="'ball'" \
    -v NODE_OPTIONS='
           --no-experimental-fetch
           --trace-warnings
           --loader=ts-node/tsm
           --loader=esmock
    ' \
    --debug
```
```javascript
[ '.env' ]
{
  foo: 'bar=baz',
  pew: 'pew',
  meow: 'mix',
  foos: "'ball'",
  NODE_OPTIONS: '\n' +
    '           --no-experimental-fetch \n' +
    '           --trace-warnings \n' +
    '           --loader=ts-node/tsm \n' +
    '           --loader=esmock\n' +
    '    '
}
```

</details>