### PR TITLE
Forward signals to child process

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -103,7 +103,7 @@ if (!command) {
   process.exit(1)
 }
 
-spawn(command, argv._.slice(1), { stdio: 'inherit' })
+const child = spawn(command, argv._.slice(1), { stdio: 'inherit' })
   .on('exit', function (exitCode, signal) {
     if (typeof exitCode === 'number') {
       process.exit(exitCode)
@@ -111,3 +111,9 @@ spawn(command, argv._.slice(1), { stdio: 'inherit' })
       process.kill(process.pid, signal)
     }
   })
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGPIPE', 'SIGHUP', 'SIGBREAK', 'SIGWINCH', 'SIGUSR1', 'SIGUSR2']) {
+  process.on(signal, function () {
+    child.kill(signal)
+  })
+}


### PR DESCRIPTION
I ran into an issue where I would Ctrl-C a running process, and dotenv-cli would forward the resulting `SIGINT` signal to the child process, but would also immediately terminate, leaving the child process in a kind of zombie state.

You can see this in action using the following test file:

```javascript
import { once } from "node:events";

// simulate a long-running process, e.g. a server
// that should only quit when SIGINT is received
const handle = setInterval(() => {}, 5000);

console.log("Running, press Ctrl+C to exit.");

await once(process, "SIGINT");
console.log("Received SIGINT, will exit in 5 seconds...");

setTimeout(() => {
  console.log("Exiting.");
  clearInterval(handle);
}, 5000);
```

This should produce the following output (pressing Ctrl+C at the appropriate time):

```
$ node test.mjs
Running, press Ctrl+C to exit.
^CReceived SIGINT, will exit in 5 seconds...
Exiting.
$
```

Note that the new shell prompt appears once the script has fully exited.

Running `npx dotenv -- node test.mjs` currently will produce the following output (again, pressing Ctrl+C at the appropriate time).

```
$ node test.js
Running, press Ctrl+C to exit.
^CReceived SIGINT, will exit in 5 seconds...
$ Exiting.
```

Note that the prompt appears once the parent `dotenv` program has finished, but the child `test.mjs` continues running after this point.

This PR explicitly forwards a number of signals to the child process.  This ensures that the signals are not handled in `dotenv-cli` itself, but always in the child process, which prevents the above case where the parent process terminates prematurely.

I have added a bunch of signals that I think should be relevant in various cross-platform situations, but I'm not wedded to this particular set of signals here.