### PR TITLE
Fix: Allow dashes in environment variable names

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,7 +56,7 @@ if (argv.c) {
 }
 
 function validateCmdVariable (param) {
-  const [, key, val] = param.match(/^(\w+)=([\s\S]+)$/m) || []
+  const [, key, val] = param.match(/^([\w-]+)=([\s\S]+)$/m) || []
   if (!key || !val) {
     console.error(`Invalid variable name. Expected variable in format '-v variable=value', but got: \`-v ${param}\`.`)
     process.exit(1)


### PR DESCRIPTION
Updated the regex in `validateCmdVariable` to support environment variable names containing dashes (`-`). Modified the pattern from `^(\w+)=([\s\S]+)$` to `^([\w-]+)=([\s\S]+)$` to include dashes alongside alphanumeric characters and underscores. This change enables the correct parsing of variables with dashes in `.env` files.

FYI I created this PR because Azure KeyVault doesn't support underscores, only hyphens.